### PR TITLE
Clarify info about the GSoC proposal submission

### DIFF
--- a/gsoc/students-guideline.md
+++ b/gsoc/students-guideline.md
@@ -37,6 +37,7 @@ Get started checking out the [Google Summer of Code Guides for students](https:/
   * A detailed plan of work with a timeline spanning over **90 or 175 or 375 hours**, which is the GSoC coding period duration this year. Note that your availability for working on the project has to be clearly stated (agreed upon with your mentors) and represents an engagement on your side. Breaking it during the coding period without prior notice and mentor's agreement represents a reason for being failed.
   * Well defined tasks and their objectives, with a list of deliverables upon which the success of the project will be determined.
   * Between **Mar 18 - Mar 26** you will have the possibility to share your proposal draft with the project mentors to get improvement suggestions, before making your GSoC application due on **Apr 2**.
+  * Make sure to submit the proposal through the GSoC dashboard, not only to mentors.
 <br><br>
 
 6. Your proposal will be evaluated and ranked by your mentors, who give their feedback to the HSF Org Admins. If a project has eligible candidates, it will be considered for the request of slots made to GSoC, due on **Apr 20**. Note that the result of this Phase 2 selection process cannot be made available before the official announcement by Google of the successful student projects, on **May 1**.


### PR DESCRIPTION
Adding a small bullet point emphasising the need for submitting the proposals via GSoC system, not only to mentors (it was not clear in the past for my 2 students who did not do it and could not be later selected).